### PR TITLE
Grid styles for classic theme, v1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 Changes
 =======
 
-In next release ...
+1.5 (2012-10-12)
+----------------
 
 Features:
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(*pathnames):
     return open(os.path.join(os.path.dirname(__file__), *pathnames)).read().\
            decode('utf-8')
 
-version = '1.4'
+version = '1.5-dev'
 
 setup(name='collective.panels',
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(*pathnames):
     return open(os.path.join(os.path.dirname(__file__), *pathnames)).read().\
            decode('utf-8')
 
-version = '1.5-dev'
+version = '1.5'
 
 setup(name='collective.panels',
       version=version,

--- a/src/collective/panels/configure.zcml
+++ b/src/collective/panels/configure.zcml
@@ -225,6 +225,12 @@
       layer=".interfaces.ILayer"
       />
 
+  <browser:resource
+      name="panels-grid-classic-theme.css"
+      file="styles-classic-theme-grid.css"
+      layer="plonetheme.classic.browser.interfaces.IThemeSpecific"
+      />
+
   <!-- Vocabularies -->
 
   <utility

--- a/src/collective/panels/configure.zcml
+++ b/src/collective/panels/configure.zcml
@@ -16,6 +16,15 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <genericsetup:upgradeStep
+      title="Update registry schema"
+      description="New options introduced"
+      source="1.0"
+      destination="1.1"
+      handler="collective.panels.upgrades.add_plone_grid_styles"
+      profile="collective.panels:default"
+      />
+
   <!-- Translations -->
 
   <i18n:registerTranslations directory="locales" />

--- a/src/collective/panels/profile/cssregistry.xml
+++ b/src/collective/panels/profile/cssregistry.xml
@@ -4,6 +4,9 @@
       id="++resource++panels.css"
       />
   <stylesheet
+      id="panels-grid.css"
+      />
+  <stylesheet
       id="++resource++panels-grid-classic-theme.css"
       />
 </object>

--- a/src/collective/panels/profile/cssregistry.xml
+++ b/src/collective/panels/profile/cssregistry.xml
@@ -3,4 +3,7 @@
   <stylesheet
       id="++resource++panels.css"
       />
+  <stylesheet
+      id="++resource++panels-grid-classic-theme.css"
+      />
 </object>

--- a/src/collective/panels/profile/metadata.xml
+++ b/src/collective/panels/profile/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
- <version>1.0</version>
+ <version>1.1</version>
  <dependencies>
  </dependencies>
 </metadata>

--- a/src/collective/panels/styles-classic-theme-grid.css
+++ b/src/collective/panels/styles-classic-theme-grid.css
@@ -1,0 +1,17 @@
+div.row {
+  float: left;
+  width: 100%;
+  display: block;
+  position: relative;
+}
+div.cell {
+  position: relative;
+  float: left;
+  left: 100%;
+}
+/* IE8: keeps livesearch from falling behind content area,
+   and display menu from falling behind footer
+   Keeping float for IE7, so the portlets don't fall */
+.ie6 div.cell {
+    float: none;
+}

--- a/src/collective/panels/upgrades.py
+++ b/src/collective/panels/upgrades.py
@@ -1,0 +1,16 @@
+import logging
+
+from Products.CMFCore.utils import getToolByName
+
+
+PROFILE_ID = 'profile-collective.panels:default'
+
+
+def add_plone_grid_styles(context, logger = None):
+    if logger is None:
+        # Called as upgrade step: define our own logger.
+        logger = logging.getLogger('collective.panels')
+        logger.info("Adding new stylesheets to CSS registry")
+    css_registry = getToolByName(context, 'portal_css')
+    css_registry.registerStylesheet('panels-grid.css')
+    css_registry.registerStylesheet('++resource++panels-grid-classic-theme.css')


### PR DESCRIPTION
This is mostly for requesting review of the code, as I have based the work in the `1.5` tag that haven't been merged in `master` but it is the one I am using in production and triggered researching this issue.

These two commits fix the styling of the panels with the Plone Classic theme (or one based on it) and makes the style respect the options set in the control panel configlet in the Sunburst theme.

The current implementation includes the `styles-classic-theme-grid.css` in the CSS registry unconditionally, but that file is only available with the `plonetheme.classic.browser.interfaces.IThemeSpecific` browser layer, returning a `404` if not present. Maybe a non-issue, but couldn't think of a way to do it without this happening.
