### PR TITLE
Added navigation_local option 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ In next release ...
 
 Features:
 
+- Added navigation_local option - for setting local panel managers
+  on INavigationRoot instead of ISiteRoot. Useful eg. with modules for
+  multilingual content.
+  [tmog]
+
 - Added function to duplicate an existing panel.
 
 - The "Manage panels" form now has a better default styling.

--- a/src/collective/panels/interfaces.py
+++ b/src/collective/panels/interfaces.py
@@ -74,6 +74,16 @@ class IGlobalSettings(Interface):
             )
         )
 
+    navigation_local = schema.Bool(
+        title=_(u"Use navigation root"),
+        description=_(u"Site-local panel managers will be assignable "
+                      u"on navigation roots instead of only site roots "
+                      u"if you select this option. Check this if you are "
+                      u"using LinguaPlone, collective.multilingual or "
+                      u"similar, and you want per-language Site-local "
+                      u"panel managers."),
+        )
+
     spacing = schema.Float(
         title=_(u"Column spacing"),
         description=_(u"This is the horizontal distance between "

--- a/src/collective/panels/locales/collective.panels.pot
+++ b/src/collective/panels/locales/collective.panels.pot
@@ -136,3 +136,9 @@ msgstr ""
 
 msgid "Spacing changed"
 msgstr ""
+
+msgid "Use navigation root"
+msgstr ""
+
+msgid "Site-local panel managers will be assignable on navigation roots instead of only site roots if you select this option. Check this if you are using LinguaPlone, collective.multilingual or similar, and you want per-language Site-local panel managers.Spacing changed"
+msgstr ""

--- a/src/collective/panels/locales/da/LC_MESSAGES/collective.panels.po
+++ b/src/collective/panels/locales/da/LC_MESSAGES/collective.panels.po
@@ -162,3 +162,9 @@ msgid "Select this option to omit margins on the left- and right side of a panel
 msgstr "Vælg denne mulighed for at udelade venstre- og højre-margen omkring et panel."
 msgid "Manage panels"
 msgstr "Administrer paneler"
+
+msgid "Use navigation root"
+msgstr "Benyt navigationrod i stedet for siterod"
+
+msgid "Site-local panel managers will be assignable on navigation roots instead of only site roots if you select this option. Check this if you are using LinguaPlone, collective.multilingual or similar, and you want per-language Site-local panel managers."
+msgstr "Vælg dette hvis sitet bruger LinguaPlone, collective.multilingual el.lign. modul til indholdsoversættelse. Placeringer med oprettelse på site-basis vil derefter kunne konfigureres per sprog."


### PR DESCRIPTION
for setting local panel managers on INavigationRoot instead of ISiteRoot. Useful eg. with modules for multilingual content.
